### PR TITLE
feat: implement useApi hook for simplified API requests with loading …

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+'use client'
+
+import axios, { AxiosRequestConfig } from 'axios'
+import { useCallback, useState } from 'react'
+
+export function useApi<T = any>() {
+    const [loading, set_loading] = useState(false)
+    const [error, set_error] = useState<string | null>(null)
+    const [data, set_data] = useState<T | null>(null)
+
+    const request = useCallback(
+        async (url: string, config?: AxiosRequestConfig) => {
+            set_loading(true)
+
+            try {
+                const response = await axios(url, config)
+                set_data(response.data)
+                return response.data
+            } catch (err: any) {
+                set_error(err.response?.data?.message || 'An error occurred')
+                throw err
+            } finally {
+                set_loading(false)
+            }
+        },
+        []
+    )
+
+    return [loading, error, data, request]
+}


### PR DESCRIPTION
This pull request introduces a new custom React hook, `useApi`, to streamline API requests and manage related state. The hook simplifies handling loading states, errors, and response data, enhancing code reusability and readability.

### New feature: `useApi` hook

* A custom React hook, `useApi`, was added to `src/hooks/useApi.ts`. It provides a reusable way to manage API requests, including tracking loading states, handling errors, and storing response data. The hook uses `axios` for HTTP requests and includes TypeScript support with a generic type parameter for the response data.…and error handling