### PR TITLE
fix: update build script in package.json to include prisma generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
-  "name": "expenses-tracker",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
-  "dependencies": {
-    "@prisma/client": "^6.7.0",
-    "axios": "^1.9.0",
-    "bcryptjs": "^3.0.2",
-    "jsonwebtoken": "^9.0.2",
-    "next": "15.3.0",
-    "nodemailer": "^6.10.1",
-    "prisma": "^6.7.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
-  "devDependencies": {
-    "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
-    "@types/jsonwebtoken": "^9.0.9",
-    "@types/node": "^20",
-    "@types/nodemailer": "^6.4.17",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "15.3.0",
-    "tailwindcss": "^4",
-    "typescript": "^5"
-  }
+    "name": "expenses-tracker",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev --turbopack",
+        "build": "prisma generate && next build",
+        "postinstall": "prisma generate",
+        "start": "next start",
+        "lint": "next lint"
+    },
+    "dependencies": {
+        "@prisma/client": "^6.7.0",
+        "axios": "^1.9.0",
+        "bcryptjs": "^3.0.2",
+        "jsonwebtoken": "^9.0.2",
+        "next": "15.3.0",
+        "nodemailer": "^6.10.1",
+        "prisma": "^6.7.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+    },
+    "devDependencies": {
+        "@eslint/eslintrc": "^3",
+        "@tailwindcss/postcss": "^4",
+        "@types/jsonwebtoken": "^9.0.9",
+        "@types/node": "^20",
+        "@types/nodemailer": "^6.4.17",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "eslint": "^9",
+        "eslint-config-next": "15.3.0",
+        "tailwindcss": "^4",
+        "typescript": "^5"
+    }
 }


### PR DESCRIPTION
This pull request updates the `package.json` file to integrate Prisma into the build process. The most important change is the addition of Prisma-related commands to the build and post-installation scripts.

Build process updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R8): Modified the `build` script to include `prisma generate` before running `next build`, ensuring that Prisma client files are generated during the build process. Added a `postinstall` script to automatically run `prisma generate` after dependencies are installed.